### PR TITLE
[WIP] fix: use type set where order may change

### DIFF
--- a/provider/resource_authentication.go
+++ b/provider/resource_authentication.go
@@ -10,10 +10,10 @@ func resourceAuthentication() *schema.Resource {
 	schema := map[string]*schema.Schema{
 		"url": &schema.Schema{
 			Type:     schema.TypeString,
-			Optional: true,
+			Required: true,
 		},
 		"scope": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Optional: true,
 		},
@@ -39,12 +39,12 @@ func resourceAuthentication() *schema.Resource {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"forwarded_request_parameters": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"claims_to_sync": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},

--- a/provider/resource_credential_config.go
+++ b/provider/resource_credential_config.go
@@ -23,12 +23,12 @@ func resourceCredentialConfig() *schema.Resource {
 			Required: true,
 		},
 		"additional_types": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"contexts": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},

--- a/provider/resource_did.go
+++ b/provider/resource_did.go
@@ -22,7 +22,7 @@ func resourceDid() *schema.Resource {
 			ForceNew:    true,
 		},
 		"keys": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Computed: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/provider/resource_issuer.go
+++ b/provider/resource_issuer.go
@@ -34,12 +34,12 @@ func resourceIssuer() *schema.Resource {
 			Optional: true,
 		},
 		"context": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"type": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
@@ -60,7 +60,7 @@ func resourceIssuer() *schema.Resource {
 			Required: true,
 		},
 		"scope": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
@@ -90,12 +90,12 @@ func resourceIssuer() *schema.Resource {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"forwarded_request_parameters": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"claim_mappings": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/provider/resource_issuer_client.go
+++ b/provider/resource_issuer_client.go
@@ -20,17 +20,17 @@ func resourceIssuerClient() *schema.Resource {
 			Required: true,
 		},
 		"redirect_uris": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"response_types": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"grant_types": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},

--- a/provider/resource_verifier.go
+++ b/provider/resource_verifier.go
@@ -18,7 +18,7 @@ func resourceVerifier() *schema.Resource {
 			Required: true,
 		},
 		"claim_mapping": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/provider/resource_verifier_client.go
+++ b/provider/resource_verifier_client.go
@@ -20,17 +20,17 @@ func resourceVerifierClient(client api.Client) *schema.Resource {
 			Required: true,
 		},
 		"redirect_uris": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Required: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"response_types": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"grant_types": &schema.Schema{
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},

--- a/provider/resource_webhook.go
+++ b/provider/resource_webhook.go
@@ -13,7 +13,7 @@ func resourceWebhook(client api.Client) *schema.Resource {
 		Client: client,
 		Schema: map[string]*schema.Schema{
 			"events": &schema.Schema{
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
MATTR's API does not always return lists in the order you uploaded them. This changes it to use TypeSet, which is more suitable for many types of data.